### PR TITLE
Add h- and v- margin/padding Shortcuts

### DIFF
--- a/mixins/declarations.less
+++ b/mixins/declarations.less
@@ -121,3 +121,21 @@
 .reset-filter() {
 	filter: e(%("progid:DXImageTransform.Microsoft.gradient(enabled = false)"));
 }
+
+// Shortcuts for setting horizontal or vertical padding/margin at once.
+.h-margin(@val) {
+	margin-left: @val;
+	margin-right: @val;
+}
+.v-margin(@val) {
+	margin-top: @val;
+	margin-bottom: @val;
+}
+.h-padding(@val) {
+	padding-left: @val;
+	padding-right: @val;
+}
+.v-padding(@val) {
+	padding-top: @val;
+	padding-bottom: @val;
+}


### PR DESCRIPTION
This adds four new mixins (h-margin, v-margin, h-padding, and v-padding) for setting only the values you want without duplicating them. This is preferable to using the CSS shorthand (which requires you to enter both the vertical and horizontal padding), and to separate -left and -right (or -top and -bottom) values, which requires you to duplicate the value.
