### PR TITLE
Target & in .placeholder mixin

### DIFF
--- a/mixins/placeholder.less
+++ b/mixins/placeholder.less
@@ -1,18 +1,18 @@
 // placeholder mixin
 // usage
-// #selector {
-//   .placeholder-styles() {
-//     color: red;
-//   }
-//   .placeholder(~'[type="name"]');
-// }
-.placeholder (@el:~'[placeholder]') {
-  @{el}::-webkit-input-placeholder { .placeholder-styles; }
-  @{el}:-ms-input-placeholder { .placeholder-styles; }
-  @{el}::input-placeholder { .placeholder-styles; }
-  @{el}:input-placeholder { .placeholder-styles; }
-  @{el}::-moz-placeholder { .placeholder-styles; }
-  @{el}:-moz-placeholder { .placeholder-styles; }
-  @{el}::placeholder { .placeholder-styles; }
-  @{el}:placeholder { .placeholder-styles; }
+//     input {
+//         .placeholder-styles() {
+//             color: red;
+//         }
+//         .placeholder();
+//     }
+.placeholder() {
+  &::-webkit-input-placeholder { .placeholder-styles; }
+  &:-ms-input-placeholder { .placeholder-styles; }
+  &::input-placeholder { .placeholder-styles; }
+  &:input-placeholder { .placeholder-styles; }
+  &::-moz-placeholder { .placeholder-styles; }
+  &:-moz-placeholder { .placeholder-styles; }
+  &::placeholder { .placeholder-styles; }
+  &:placeholder { .placeholder-styles; }
 }


### PR DESCRIPTION
The previous approach added a descendant selector (space) which ramped
up specificity when not used globally. Since this mixin shouldn't
generally be used globally (.placeholder-styles becomes
non-overridable because of LESS's scoping rules), there was no way
around it. The new version operates on "&", meaning you can use any
selector to directly target the placeholder elements (input, textarea,
etc.) without adding unwanted specificity.
